### PR TITLE
Fix Compile Error Caused by Rust Update (return_position_impl_trait_in_trait)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(return_position_impl_trait_in_trait)]
 #![doc = include_str!("../README.md")]
 
 pub mod atomic;


### PR DESCRIPTION
This is not stable and not needed since Rust 1.75.0, and throws fatal compile error if not removed.

```text
1 | #![feature(return_position_impl_trait_in_trait)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the attribute
  |
  = help: the feature return_position_impl_trait_in_trait has been stable since 1.75.0 and no longer requires an attribute to enable
```

Should be pretty straight forward PR :smile: 