### PR TITLE
Add serde derives to MinHash and MinHashArray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ categories = [
 siphasher = "0.3"
 fnv = "1.0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde-big-array = "0.5"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/minhash.rs
+++ b/src/minhash.rs
@@ -9,12 +9,16 @@ use crate::{
 use core::hash::Hash;
 use core::ops::Index;
 use core::ops::IndexMut;
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
 
 use crate::prelude::Maximal;
 
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(bound(serialize = "Word: Serialize", deserialize = "Word: Deserialize<'de>"))]
 pub struct MinHash<Word, const PERMUTATIONS: usize> {
+    #[serde(with = "BigArray")]
     words: [Word; PERMUTATIONS],
 }
 

--- a/src/minhash_array.rs
+++ b/src/minhash_array.rs
@@ -1,10 +1,15 @@
 use core::ops::{Index, IndexMut};
 
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+
 use crate::prelude::*;
 
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(serialize = "Word: Serialize", deserialize = "Word: Deserialize<'de>"))]
 pub struct MinHashArray<Word, const PERMUTATIONS: usize, const N: usize> {
+    #[serde(with = "BigArray")]
     counters: [MinHash<Word, PERMUTATIONS>; N],
 }
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,0 +1,64 @@
+//! Serde round-trip tests for MinHash and MinHashArray.
+
+use minhash_rs::prelude::*;
+
+fn roundtrip_minhash<Word, const PERMUTATIONS: usize>(values: &[u64])
+where
+    Word: Min
+        + XorShift
+        + Copy
+        + Eq
+        + Maximal
+        + Zero
+        + core::fmt::Debug
+        + serde::Serialize
+        + serde::de::DeserializeOwned,
+    u64: Primitive<Word>,
+{
+    let mut original = MinHash::<Word, PERMUTATIONS>::new();
+    for &v in values {
+        original.insert_with_siphashes13(v);
+    }
+
+    let json = serde_json::to_string(&original).expect("serialization failed");
+    let decoded: MinHash<Word, PERMUTATIONS> =
+        serde_json::from_str(&json).expect("deserialization failed");
+
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn minhash_roundtrips_across_word_types() {
+    let values: Vec<u64> = (0..50).collect();
+    roundtrip_minhash::<u8, 128>(&values);
+    roundtrip_minhash::<u16, 128>(&values);
+    roundtrip_minhash::<u32, 128>(&values);
+    roundtrip_minhash::<u64, 128>(&values);
+    roundtrip_minhash::<usize, 128>(&values);
+}
+
+#[test]
+fn minhash_roundtrips_large_permutation_count() {
+    // Exercises the BigArray path well beyond serde's built-in array limit (32).
+    let values: Vec<u64> = (0..1000).collect();
+    roundtrip_minhash::<u64, 4096>(&values);
+}
+
+#[test]
+fn minhash_array_roundtrips() {
+    const PERMUTATIONS: usize = 64;
+    const N: usize = 8;
+
+    let mut original = MinHashArray::<u64, PERMUTATIONS, N>::new();
+    for i in 0..N {
+        for v in 0..20_u64 {
+            original[i].insert_with_siphashes13(v + (i as u64) * 100);
+        }
+    }
+
+    let json = serde_json::to_string(&original).expect("serialization failed");
+    let decoded: MinHashArray<u64, PERMUTATIONS, N> =
+        serde_json::from_str(&json).expect("deserialization failed");
+
+    assert_eq!(original, decoded);
+}


### PR DESCRIPTION
The serde dependency was declared but never used because MinHash and MinHashArray were missing the Serialize and Deserialize derives. This adds them. Since the sketches hold const-generic arrays, which serde does not support past length 32, it uses serde-big-array for the array fields. Adds round-trip tests across every word type, a large permutation count, and MinHashArray.
