### PR TITLE
Harden hashing: avoid zero-state collapse, fix XorShift, bump to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minhash-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Luca Cappelletti <cappelletti.luca94@gmail.com>"]
 description = "A Rust implementation of MinHash trying to be parsimonious with memory."

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As usual, just add the following to your `Cargo.toml` file, altough remember to 
 
 ```toml
 [dependencies]
-minhash-rs = "0.1.0"
+minhash-rs = "0.3.0"
 ```
 
 ## Reason for this implementation

--- a/benches/bench_minhash_insert.rs
+++ b/benches/bench_minhash_insert.rs
@@ -5,57 +5,53 @@ use minhash_rs::prelude::*;
 
 use test::{black_box, Bencher};
 
+const NUMBER_OF_ELEMENTS: usize = 100_000;
+
 #[bench]
 fn bench_minhash_insert_with_siphashes13(b: &mut Bencher) {
-    const NUMBER_OF_ELEMENTS: usize = 100_000;
-    let mut hll: MinHash<u64, 128> = MinHash::new();
-
     b.iter(|| {
-        // Inner closure, the actual test
-        black_box(for i in 0..NUMBER_OF_ELEMENTS {
-            hll.insert_with_siphashes13(i)
-        });
+        let mut minhash: MinHash<u64, 128> = MinHash::new();
+        for i in 0..NUMBER_OF_ELEMENTS {
+            minhash.insert_with_siphashes13(black_box(i));
+        }
+        black_box(minhash)
     });
 }
 
 #[bench]
 fn bench_minhash_insert_with_keyed_siphashes13(b: &mut Bencher) {
-    const NUMBER_OF_ELEMENTS: usize = 100_000;
-    let mut hll: MinHash<u64, 128> = MinHash::new();
     let key0 = 0x0123456789ABCDEF;
     let key1 = 0xFEDCBA9876543210;
 
     b.iter(|| {
-        // Inner closure, the actual test
-        black_box(for i in 0..NUMBER_OF_ELEMENTS {
-            hll.insert_with_keyed_siphashes13(i, key0, key1);
-        });
+        let mut minhash: MinHash<u64, 128> = MinHash::new();
+        for i in 0..NUMBER_OF_ELEMENTS {
+            minhash.insert_with_keyed_siphashes13(black_box(i), key0, key1);
+        }
+        black_box(minhash)
     });
 }
 
 #[bench]
 fn bench_minhash_insert_with_fnv(b: &mut Bencher) {
-    const NUMBER_OF_ELEMENTS: usize = 100_000;
-    let mut hll: MinHash<u64, 128> = MinHash::new();
-
     b.iter(|| {
-        // Inner closure, the actual test
-        black_box(for i in 0..NUMBER_OF_ELEMENTS {
-            hll.insert_with_fnv(i)
-        });
+        let mut minhash: MinHash<u64, 128> = MinHash::new();
+        for i in 0..NUMBER_OF_ELEMENTS {
+            minhash.insert_with_fnv(black_box(i));
+        }
+        black_box(minhash)
     });
 }
 
 #[bench]
 fn bench_minhash_insert_with_keyed_fnv(b: &mut Bencher) {
-    const NUMBER_OF_ELEMENTS: usize = 100_000;
-    let mut hll: MinHash<u64, 128> = MinHash::new();
     let key: u64 = 0x0123456789ABCDEF;
 
     b.iter(|| {
-        // Inner closure, the actual test
-        black_box(for i in 0..NUMBER_OF_ELEMENTS {
-            hll.insert_with_keyed_fnv(i, key)
-        });
+        let mut minhash: MinHash<u64, 128> = MinHash::new();
+        for i in 0..NUMBER_OF_ELEMENTS {
+            minhash.insert_with_keyed_fnv(black_box(i), key);
+        }
+        black_box(minhash)
     });
 }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -11,24 +11,40 @@ use crate::prelude::*;
 ///
 /// This is shared by both the non-atomic [`IterHashes`] machinery and the
 /// atomic insertion path so that the two stay byte-for-byte compatible.
+///
+/// Zero is never emitted. XorShift has zero as a fixed point, so a hash that
+/// ever reaches zero would stay zero for the rest of the stream. In particular,
+/// when the seed truncates to zero (about one value in 256 for an 8-bit word)
+/// the whole stream would collapse to zero and saturate the sketch from a
+/// single insertion. Remapping zero to one keeps the stream non-degenerate for
+/// every word width.
 fn iter_word_hashes<Word, H, HS>(
     value: H,
     mut hasher: HS,
     count: usize,
 ) -> impl Iterator<Item = Word>
 where
-    Word: XorShift + Copy,
+    Word: XorShift + Copy + PartialEq,
     u64: Primitive<Word>,
     H: Hash,
     HS: Hasher,
 {
+    let zero: Word = 0u64.convert();
+    let one: Word = 1u64.convert();
+
     // Calculate the hash.
     value.hash(&mut hasher);
     let mut hash: Word = hasher.finish().splitmix().splitmix().convert();
+    if hash == zero {
+        hash = one;
+    }
 
-    // Iterate over the words.
+    // Iterate over the words, never emitting the degenerate zero state.
     (0..count).map(move |_| {
         hash = hash.xorshift();
+        if hash == zero {
+            hash = one;
+        }
         hash
     })
 }
@@ -303,7 +319,7 @@ pub trait AtomicFetchInsert {
 impl<A> AtomicFetchInsert for [A]
 where
     A: AtomicFetchMin,
-    A::Word: XorShift + Copy,
+    A::Word: XorShift + Copy + PartialEq,
     u64: Primitive<A::Word>,
 {
     type Word = A::Word;

--- a/src/minhash.rs
+++ b/src/minhash.rs
@@ -4,7 +4,6 @@ use crate::{
     atomic::IterHashes,
     prelude::{Min, Primitive},
     xorshift::XorShift,
-    zero::Zero,
 };
 use core::hash::Hash;
 use core::ops::Index;
@@ -56,7 +55,7 @@ impl<Word: Maximal, const PERMUTATIONS: usize> MinHash<Word, PERMUTATIONS> {
     }
 }
 
-impl<Word: Min + XorShift + Copy + Eq + Maximal + Zero, const PERMUTATIONS: usize>
+impl<Word: Min + XorShift + Copy + Eq + Maximal, const PERMUTATIONS: usize>
     MinHash<Word, PERMUTATIONS>
 where
     u64: Primitive<Word>,
@@ -81,6 +80,12 @@ where
 
     /// Returns whether the MinHash is fully saturated.
     ///
+    /// A sketch is saturated once every word has reached the smallest hash value
+    /// the generator can produce, which is one (zero is never emitted, see the
+    /// hash generator). Wide words such as `u64` cannot realistically be
+    /// saturated, but narrow words such as `u8` saturate after enough distinct
+    /// insertions.
+    ///
     /// # Examples
     ///
     /// ```
@@ -90,7 +95,7 @@ where
     ///
     /// assert!(!minhash.is_full());
     ///
-    /// for i in 0..1024 {
+    /// for i in 0..4096 {
     ///    minhash.insert_with_siphashes13(i);
     /// }
     ///
@@ -98,7 +103,8 @@ where
     /// ```
     ///
     pub fn is_full(&self) -> bool {
-        self.iter().all(|word| *word == Word::zero())
+        let one: Word = 1u64.convert();
+        self.iter().all(|word| *word == one)
     }
 }
 
@@ -422,6 +428,17 @@ impl<Word: Eq, const PERMUTATIONS: usize> MinHash<Word, PERMUTATIONS> {
     /// # Arguments
     /// * `other` - The other MinHash to compare to.
     ///
+    /// # Edge cases
+    /// Two empty sketches are identical (every word is the maximal sentinel), so
+    /// the estimate is `1.0`. The Jaccard index of two empty sets is undefined
+    /// (0/0); this method treats identical sketches as perfectly similar.
+    ///
+    /// ```
+    /// use minhash_rs::prelude::*;
+    ///
+    /// let empty = MinHash::<u64, 128>::new();
+    /// assert_eq!(empty.estimate_jaccard_index(&empty), 1.0);
+    /// ```
     ///
     /// # Examples
     ///

--- a/src/xorshift.rs
+++ b/src/xorshift.rs
@@ -6,44 +6,47 @@
 
 pub trait XorShift {
     /// Returns the next value in the xorshift sequence.
-    fn xorshift(&mut self) -> Self;
+    fn xorshift(self) -> Self;
 }
 
 impl XorShift for usize {
-    fn xorshift(&mut self) -> Self {
-        (*self as u64).xorshift() as usize
+    fn xorshift(self) -> Self {
+        (self as u64).xorshift() as usize
     }
 }
 
 impl XorShift for u64 {
-    fn xorshift(&mut self) -> Self {
-        *self ^= *self << 13;
-        *self ^= *self >> 7;
-        *self ^= *self << 17;
-        *self
+    fn xorshift(self) -> Self {
+        let mut x = self;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        x
     }
 }
 
 impl XorShift for u32 {
-    fn xorshift(&mut self) -> Self {
-        *self ^= *self << 13;
-        *self ^= *self >> 17;
-        *self ^= *self << 5;
-        *self
+    fn xorshift(self) -> Self {
+        let mut x = self;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        x
     }
 }
 
 impl XorShift for u16 {
-    fn xorshift(&mut self) -> Self {
-        (*self as u32).xorshift() as u16
+    fn xorshift(self) -> Self {
+        (self as u32).xorshift() as u16
     }
 }
 
 impl XorShift for u8 {
-    fn xorshift(&mut self) -> Self {
-        *self ^= *self << 3;
-        *self ^= *self >> 7;
-        *self ^= *self << 1;
-        *self
+    fn xorshift(self) -> Self {
+        let mut x = self;
+        x ^= x << 3;
+        x ^= x >> 7;
+        x ^= x << 1;
+        x
     }
 }

--- a/tests/test_word_types.rs
+++ b/tests/test_word_types.rs
@@ -58,12 +58,25 @@ fn memory_matches_word_width() {
 
 #[test]
 fn small_words_saturate_and_report_full() {
-    // A u8 sketch has only 256 distinct hash values per permutation, so a large
-    // universe drives every word down to zero, at which point the sketch is full.
+    // A u8 sketch has few distinct hash values per permutation, so a large
+    // universe drives every word down to the minimum hash value (one, since
+    // zero is never emitted), at which point the sketch is full.
     let mut mh = MinHash::<u8, 16>::new();
     assert!(!mh.is_full());
     for i in 0..100_000_u64 {
         mh.insert_with_siphashes13(i);
     }
     assert!(mh.is_full());
+}
+
+#[test]
+fn single_value_never_saturates_small_words() {
+    // Regression test: previously about one value in 256 truncated to a zero
+    // seed and, because XorShift fixes zero, collapsed an entire u8 sketch to
+    // full from a single insertion. No single value may saturate the sketch.
+    for v in 0..5_000_u64 {
+        let mut mh = MinHash::<u8, 32>::new();
+        mh.insert_with_siphashes13(v);
+        assert!(!mh.is_full(), "value {v} saturated the sketch on its own");
+    }
 }


### PR DESCRIPTION
Fixes several issues from a codebase review. The main one: small word types could self-destruct on a single insert. Because the seed is truncated to the word width and XorShift fixes zero, about one value in 256 produced a zero seed that collapsed an entire u8 sketch to all-zero (a u8 sketch was dead after ~135 values). The hash generator now never emits zero, so is_full tests against the smallest reachable value (one) and a regression test confirms no single value saturates a sketch.

It also makes XorShift take self by value, since the u16 and usize impls silently did not mutate the mutable self they claimed to. Plus smaller items: estimate_jaccard_index documents that two empty sketches return 1.0, the README install version is updated, and the insert benchmarks reset per iteration and black_box properly.

These change hash values and a trait signature, so the crate is bumped to 0.3.0. Tests, doctests, clippy, fmt, and Miri all pass.
