### PR TITLE
Add Codecov coverage CI job and README badge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,3 +45,23 @@ jobs:
         # integration test is a heavy benchmark (large sets, file I/O) that is
         # unsuitable for the Miri interpreter.
         run: cargo miri test --lib --test test_atomic
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly with llvm-tools-preview
+        run: |
+          rustup toolchain install nightly --component llvm-tools-preview
+          rustup default nightly
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage (lcov)
+        run: cargo llvm-cov --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Generate coverage (lcov)
         run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ Cargo.lock
 *.csv
 .ipynb_checkpoints
 *.bkp
+
+# Coverage reports
+lcov.info
+*.profraw

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Build status](https://github.com/lucacappelletti94/minhash-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/lucacappelletti94/minhash-rs/actions)
 [![Crates.io](https://img.shields.io/crates/v/minhash-rs.svg)](https://crates.io/crates/minhash-rs)
 [![Documentation](https://docs.rs/minhash-rs/badge.svg)](https://docs.rs/minhash-rs)
+[![codecov](https://codecov.io/gh/LucaCappelletti94/minhash-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/LucaCappelletti94/minhash-rs)
 
 A Rust implementation of MinHash trying to be parsimonious with memory.
 


### PR DESCRIPTION
Adds code coverage, which the project did not have. A new coverage CI job generates an lcov report with cargo-llvm-cov and uploads it to Codecov, and a Codecov badge is added to the README. Verified the coverage command runs locally and produces the report.

The upload uses a CODECOV_TOKEN repo secret, so you will need to add that secret in the repo settings (and enable the repo on codecov.io) for uploads and the badge to populate. The job uses fail_ci_if_error: false so a missing token does not break CI.
