### PR TITLE
Remove unused Primitive conversion impls

### DIFF
--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,95 +1,11 @@
+/// Conversion from a `u64` hash value into a narrower MinHash word.
+///
+/// The hash generator always produces `u64` values (from the hasher and
+/// SplitMix), so the only conversions the crate needs are from `u64` into each
+/// supported word type. The bound used throughout the crate is
+/// `u64: Primitive<Word>`.
 pub trait Primitive<T> {
     fn convert(self) -> T;
-}
-
-impl Primitive<u8> for u8 {
-    fn convert(self) -> u8 {
-        self
-    }
-}
-
-impl Primitive<u16> for u8 {
-    fn convert(self) -> u16 {
-        self as u16
-    }
-}
-
-impl Primitive<u32> for u8 {
-    fn convert(self) -> u32 {
-        self as u32
-    }
-}
-
-impl Primitive<u64> for u8 {
-    fn convert(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Primitive<usize> for u8 {
-    fn convert(self) -> usize {
-        self as usize
-    }
-}
-
-impl Primitive<u8> for u16 {
-    fn convert(self) -> u8 {
-        self as u8
-    }
-}
-
-impl Primitive<u16> for u16 {
-    fn convert(self) -> u16 {
-        self
-    }
-}
-
-impl Primitive<u32> for u16 {
-    fn convert(self) -> u32 {
-        self as u32
-    }
-}
-
-impl Primitive<u64> for u16 {
-    fn convert(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Primitive<usize> for u16 {
-    fn convert(self) -> usize {
-        self as usize
-    }
-}
-
-impl Primitive<u8> for u32 {
-    fn convert(self) -> u8 {
-        self as u8
-    }
-}
-
-impl Primitive<u16> for u32 {
-    fn convert(self) -> u16 {
-        self as u16
-    }
-}
-
-impl Primitive<u32> for u32 {
-    fn convert(self) -> u32 {
-        self
-    }
-}
-
-impl Primitive<u64> for u32 {
-    fn convert(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Primitive<usize> for u32 {
-    fn convert(self) -> usize {
-        self as usize
-    }
 }
 
 impl Primitive<u8> for u64 {
@@ -119,35 +35,5 @@ impl Primitive<u64> for u64 {
 impl Primitive<usize> for u64 {
     fn convert(self) -> usize {
         self as usize
-    }
-}
-
-impl Primitive<u8> for usize {
-    fn convert(self) -> u8 {
-        self as u8
-    }
-}
-
-impl Primitive<u16> for usize {
-    fn convert(self) -> u16 {
-        self as u16
-    }
-}
-
-impl Primitive<u32> for usize {
-    fn convert(self) -> u32 {
-        self as u32
-    }
-}
-
-impl Primitive<u64> for usize {
-    fn convert(self) -> u64 {
-        self as u64
-    }
-}
-
-impl Primitive<usize> for usize {
-    fn convert(self) -> usize {
-        self
     }
 }


### PR DESCRIPTION
The Primitive trait had a full 25-entry conversion matrix between every integer width, but the crate only ever converts from u64 (the hash generator always produces u64), and the only bound used anywhere is u64: Primitive<Word>. The other 20 impls, where the source is not u64, were never used or required, which is why primitive.rs sat at 20 percent coverage (5 of 25 functions). This keeps the five u64-source conversions and removes the rest, taking primitive.rs to full coverage. Tests, doctests, clippy, fmt, and Miri all pass.
