### PR TITLE
Expand test coverage for keyed/FNV and atomic paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,10 +41,10 @@ jobs:
           rustup default nightly
           cargo miri setup
       - name: Run Miri
-        # Scope to the lib and the atomic soundness tests. The test_jaccard
-        # integration test is a heavy benchmark (large sets, file I/O) that is
-        # unsuitable for the Miri interpreter.
-        run: cargo miri test --lib --test test_atomic
+        # Scope to the lib and the atomic soundness tests (every word width). The
+        # test_jaccard integration test is a heavy benchmark (large sets, file
+        # I/O) that is unsuitable for the Miri interpreter.
+        run: cargo miri test --lib --test test_atomic --test test_atomic_variants
 
   coverage:
     runs-on: ubuntu-latest

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -39,7 +39,11 @@ where
         hash = one;
     }
 
-    // Iterate over the words, never emitting the degenerate zero state.
+    // Iterate over the words, never emitting the degenerate zero state. The
+    // native generators (u8/u16/u32/u64) are bijections on the non-zero space,
+    // so once the seed is non-zero they never produce zero; this in-loop guard
+    // therefore only fires for widths whose generator truncates a wider type
+    // (for example `usize` on a 32-bit target), keeping the stream safe there.
     (0..count).map(move |_| {
         hash = hash.xorshift();
         if hash == zero {

--- a/tests/test_atomic_variants.rs
+++ b/tests/test_atomic_variants.rs
@@ -1,0 +1,76 @@
+//! Atomic insertion coverage for the FNV hash families and for every supported
+//! word width (the single-threaded SipHasher13 path is covered in test_atomic).
+
+use core::sync::atomic::Ordering;
+
+use minhash_rs::prelude::*;
+
+#[test]
+fn atomic_fnv_has_no_false_negatives() {
+    let mut mh = MinHash::<u64, 16>::new();
+    {
+        let atomic = mh.as_atomic();
+        for v in 0..8u64 {
+            atomic.fetch_insert_with_fnv(v, Ordering::Relaxed);
+        }
+    }
+    for v in 0..8u64 {
+        assert!(mh.may_contain_value_with_fnv(v));
+    }
+}
+
+#[test]
+fn atomic_keyed_fnv_has_no_false_negatives() {
+    let key = 0xDEAD_BEEF;
+    let mut mh = MinHash::<u64, 16>::new();
+    {
+        let atomic = mh.as_atomic();
+        for v in 0..8u64 {
+            atomic.fetch_insert_with_keyed_fnv(v, key, Ordering::Relaxed);
+        }
+    }
+    for v in 0..8u64 {
+        assert!(mh.may_contain_value_with_keyed_fnv(v, key));
+    }
+}
+
+#[test]
+fn atomic_fnv_matches_non_atomic_fnv() {
+    let mut atomic_mh = MinHash::<u64, 16>::new();
+    {
+        let atomic = atomic_mh.as_atomic();
+        atomic.fetch_insert_with_fnv(123_u64, Ordering::Relaxed);
+    }
+
+    let mut serial_mh = MinHash::<u64, 16>::new();
+    serial_mh.insert_with_fnv(123_u64);
+
+    assert_eq!(atomic_mh, serial_mh);
+}
+
+// One test per word width to exercise the `AtomicFetchMin::set_min` impl of each
+// atomic type (AtomicU8/U16/U32/Usize; AtomicU64 is covered in test_atomic).
+macro_rules! atomic_word_width_test {
+    ($name:ident, $word:ty) => {
+        #[test]
+        fn $name() {
+            let mut mh = MinHash::<$word, 16>::new();
+            assert!(mh.is_empty());
+            {
+                let atomic = mh.as_atomic();
+                for v in 0..8u64 {
+                    atomic.fetch_insert_with_siphashes13(v, Ordering::Relaxed);
+                }
+            }
+            assert!(!mh.is_empty());
+            for v in 0..8u64 {
+                assert!(mh.may_contain_value_with_siphashes13(v));
+            }
+        }
+    };
+}
+
+atomic_word_width_test!(atomic_word_width_u8, u8);
+atomic_word_width_test!(atomic_word_width_u16, u16);
+atomic_word_width_test!(atomic_word_width_u32, u32);
+atomic_word_width_test!(atomic_word_width_usize, usize);

--- a/tests/test_minhash_api.rs
+++ b/tests/test_minhash_api.rs
@@ -1,0 +1,101 @@
+//! Tests for the non-atomic MinHash API surface: the keyed SipHasher13 and FNV
+//! insert/membership variants, plus the small accessors (construction,
+//! permutation count, indexing and slice views).
+
+use minhash_rs::prelude::*;
+
+const PERMUTATIONS: usize = 128;
+
+#[test]
+fn default_equals_new() {
+    assert_eq!(
+        MinHash::<u64, PERMUTATIONS>::default(),
+        MinHash::<u64, PERMUTATIONS>::new()
+    );
+}
+
+#[test]
+fn number_of_permutations_reports_const() {
+    assert_eq!(
+        MinHash::<u64, PERMUTATIONS>::new().number_of_permutations(),
+        PERMUTATIONS
+    );
+    assert_eq!(MinHash::<u32, 64>::new().number_of_permutations(), 64);
+}
+
+#[test]
+fn keyed_siphash13_has_no_false_negatives() {
+    let key0 = 0x0123_4567_89AB_CDEF;
+    let key1 = 0xFEDC_BA98_7654_3210;
+
+    let mut mh = MinHash::<u64, PERMUTATIONS>::new();
+    let values: Vec<u64> = (0..50).collect();
+    for &v in &values {
+        mh.insert_with_keyed_siphashes13(v, key0, key1);
+    }
+    for &v in &values {
+        assert!(mh.may_contain_value_with_keyed_siphashes13(v, key0, key1));
+    }
+}
+
+#[test]
+fn keyed_fnv_has_no_false_negatives() {
+    let key = 0x0123_4567_89AB_CDEF;
+
+    let mut mh = MinHash::<u64, PERMUTATIONS>::new();
+    let values: Vec<u64> = (0..50).collect();
+    for &v in &values {
+        mh.insert_with_keyed_fnv(v, key);
+    }
+    for &v in &values {
+        assert!(mh.may_contain_value_with_keyed_fnv(v, key));
+    }
+}
+
+#[test]
+fn keyed_siphash13_same_key_matches_different_key_differs() {
+    let values: Vec<u64> = (0..200).collect();
+
+    let mut a = MinHash::<u64, PERMUTATIONS>::new();
+    let mut same = MinHash::<u64, PERMUTATIONS>::new();
+    let mut other = MinHash::<u64, PERMUTATIONS>::new();
+    for &v in &values {
+        a.insert_with_keyed_siphashes13(v, 1, 2);
+        same.insert_with_keyed_siphashes13(v, 1, 2);
+        other.insert_with_keyed_siphashes13(v, 3, 4);
+    }
+
+    assert_eq!(a, same, "the same key over the same values must match");
+    assert_ne!(a, other, "different keys should produce different sketches");
+}
+
+#[test]
+fn keyed_fnv_different_keys_differ() {
+    let values: Vec<u64> = (0..200).collect();
+
+    let mut a = MinHash::<u64, PERMUTATIONS>::new();
+    let mut b = MinHash::<u64, PERMUTATIONS>::new();
+    for &v in &values {
+        a.insert_with_keyed_fnv(v, 7);
+        b.insert_with_keyed_fnv(v, 99);
+    }
+    assert_ne!(a, b);
+}
+
+#[test]
+fn indexing_and_slice_views_expose_words() {
+    let mut mh = MinHash::<u64, 8>::new();
+
+    // A fresh sketch is all maximal sentinels, visible via Index and AsRef.
+    assert_eq!(mh[0], u64::MAX);
+    assert_eq!(mh.as_ref().len(), 8);
+    assert!(mh.as_ref().iter().all(|&w| w == u64::MAX));
+
+    // IndexMut and AsMut both allow direct word mutation.
+    mh[0] = 123;
+    assert_eq!(mh[0], 123);
+    assert_eq!(mh.as_ref()[0], 123);
+
+    mh.as_mut()[1] = 456;
+    assert_eq!(mh[1], 456);
+}


### PR DESCRIPTION
Expands the test suite to cover the reachable code that previously had no tests, mostly the keyed SipHasher13, FNV and keyed FNV variants (which only had doctests, and cargo-llvm-cov does not run doctests) and the accessors. A new test_minhash_api suite covers the keyed and FNV insert/membership methods, default, number_of_permutations, indexing and the slice views, and a new test_atomic_variants suite covers atomic FNV inserts and the atomic path for every word width (u8, u16, u32, usize), which also exercises the as_atomic transmute for each atomic type, so the Miri job now runs it too.

This takes line coverage from about 81 to 99.7 percent, with every module at 100 percent except one defensive line in the hash generator. While investigating that line I brute-forced the u8 and u16 spaces and confirmed the native xorshift generators never map a non-zero value to zero, so once the seed is non-zero the in-loop zero guard only matters for widths that truncate a wider generator (such as usize on a 32-bit target); the comment now says so, and that single line stays uncovered on a 64-bit runner by design. Tests, doctests, clippy, fmt, and Miri all pass.
