### PR TITLE
Make the crate no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,21 @@ jobs:
         # warning into a hard error across every target.
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  no-std:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly with a bare-metal target
+        run: |
+          rustup toolchain install nightly
+          rustup default nightly
+          rustup target add x86_64-unknown-none
+      - name: Build for a no_std target
+        # Building the library and its dependency graph for a target with no std
+        # available guarantees the crate stays no_std.
+        run: cargo build --target x86_64-unknown-none
+
   miri:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 keywords = ["minhash", "probabilistic", "algorithm", "cardinality", "estimation",]
 categories = [
+    "no-std",
     "algorithms",
     "science"
 ]
@@ -46,8 +47,8 @@ cast_precision_loss = "allow"
 transmute_ptr_to_ptr = "allow"
 
 [dependencies]
-siphasher = "0.3"
-fnv = "1.0.3"
+siphasher = { version = "0.3", default-features = false }
+fnv = { version = "1.0.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-big-array = "0.5"
 

--- a/src/from_iter.rs
+++ b/src/from_iter.rs
@@ -1,6 +1,6 @@
 //! `FromIterator` implementation that builds a MinHash from an iterator.
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 use crate::prelude::{Maximal, Min, MinHash, Primitive, XorShift};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![no_std]
 
 pub mod atomic;
 pub mod from_iter;

--- a/src/union.rs
+++ b/src/union.rs
@@ -1,6 +1,6 @@
 //! Union (merge) of MinHash sketches via the bitwise-or operators.
 
-use std::ops::{BitOr, BitOrAssign};
+use core::ops::{BitOr, BitOrAssign};
 
 use crate::prelude::{Maximal, Min, MinHash};
 


### PR DESCRIPTION
Makes the crate genuinely no_std, which the no-std category previously claimed but the code did not honor. The library only needed core: two std imports (in from_iter and union) become core, and the crate gets a #![no_std] attribute. No dependency had to be dropped, siphasher, fnv and serde-big-array all support no_std once siphasher and fnv are pulled with default-features = false. The whole dependency graph builds for the bare-metal x86_64-unknown-none target, and a new CI job builds against it so no_std cannot silently regress. The no-std category is restored now that it is accurate.
