### PR TITLE
Add MSRV, CHANGELOG, README example, and target_has_atomic gating

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,15 +38,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install nightly with a bare-metal target
+      - name: Install nightly with bare-metal targets
         run: |
           rustup toolchain install nightly
           rustup default nightly
-          rustup target add x86_64-unknown-none
-      - name: Build for a no_std target
+          rustup target add x86_64-unknown-none thumbv6m-none-eabi
+      - name: Build for a no_std target with atomics
         # Building the library and its dependency graph for a target with no std
         # available guarantees the crate stays no_std.
         run: cargo build --target x86_64-unknown-none
+      - name: Build for a no_std target without atomics
+        # thumbv6m has no atomic CAS, so this checks the target_has_atomic gating:
+        # the core sketch must compile even when the atomic API is unavailable.
+        run: cargo build --target thumbv6m-none-eabi
+
+  msrv:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the minimum supported Rust version
+        run: |
+          rustup toolchain install 1.75.0 --profile minimal
+          rustup default 1.75.0
+      - name: Build on the MSRV
+        run: cargo build
 
   miri:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format is
+loosely based on Keep a Changelog, and the project follows semantic versioning.
+
+## 0.3.0
+
+This release contains several breaking changes alongside correctness fixes,
+hardening and tooling. Upgrading from 0.2 requires the migration notes below.
+
+### Breaking
+
+- Renamed the misspelled `fvn` hash methods to `fnv` (Fowler-Noll-Vo), for
+  example `insert_with_fnv` and `may_contain_value_with_fnv`.
+- Reworked the atomic insertion API. The unsound `transmute` of a shared
+  `&[Word]` into a slice of atomics was replaced by `AsAtomic::as_atomic`, which
+  derives the atomic view from an exclusive `&mut self` borrow. Concurrent
+  inserts now go through `minhash.as_atomic().fetch_insert_with_*(...)` instead
+  of calling the insert methods directly on the sketch.
+- Renamed the set-combining operation from `intersection` to `union` and changed
+  the operator from `&` (`BitAnd`) to `|` (`BitOr`). The operation always
+  produced the union (merge) sketch, never the intersection, so the name and
+  operator were corrected.
+- Removed the unused `Zero` trait and the unreachable `Min`/`Maximal`
+  implementations for `u128`.
+- Trimmed the `Primitive` trait to the `u64`-source conversions actually used by
+  the crate.
+- `XorShift::xorshift` now takes `self` by value instead of `&mut self`.
+
+### Fixed
+
+- Fixed undefined behavior in the atomic insertion path (see above), now
+  verified under Miri.
+- Fixed small word types collapsing to a saturated sketch from a single
+  insertion: the hash generator no longer emits zero (which is an XorShift fixed
+  point), so a value whose seed truncated to zero no longer wipes the sketch.
+- Implemented `Maximal` for `usize`, which was missing and prevented constructing
+  a `MinHash` over `usize`.
+- `is_full` now tests against the smallest reachable hash value (one) rather than
+  zero, which is no longer reachable.
+
+### Added
+
+- Serde `Serialize`/`Deserialize` for `MinHash` and `MinHashArray` (using
+  `serde-big-array` for the const-generic arrays).
+- The crate is now `#![no_std]`. The atomic implementations are gated on
+  `target_has_atomic`, so the core sketch works on targets without the relevant
+  atomics.
+- Documentation for the full public API, a usage example, a strict lint gate
+  (clippy pedantic and cargo, plus `missing_docs`), code coverage in CI, and a
+  Miri job covering the atomic path across every word width.
+
+### Notes
+
+- Minimum supported Rust version is 1.75.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "minhash-rs"
 version = "0.3.0"
 edition = "2021"
+rust-version = "1.75"
 authors = ["Luca Cappelletti <cappelletti.luca94@gmail.com>"]
 description = "A Rust implementation of MinHash trying to be parsimonious with memory."
 homepage = "https://github.com/LucaCappelletti94/minhash-rs"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,34 @@ As usual, just add the following to your `Cargo.toml` file, although remember to
 minhash-rs = "0.3.0"
 ```
 
+### Example
+Build a sketch from each set and estimate their Jaccard similarity:
+
+```rust
+use std::collections::HashSet;
+use minhash_rs::prelude::*;
+
+let left: HashSet<u64> = (0..100).collect();
+let right: HashSet<u64> = (50..150).collect();
+
+// A MinHash over `u64` words with 256 permutations.
+let left_sketch: MinHash<u64, 256> = left.iter().collect();
+let right_sketch: MinHash<u64, 256> = right.iter().collect();
+
+let estimate = left_sketch.estimate_jaccard_index(&right_sketch);
+
+// The true Jaccard index here is 50 / 150 = 1/3.
+let truth = 1.0 / 3.0;
+assert!((estimate - truth).abs() < 0.1);
+
+// Sketches can also be merged: `a | b` is the sketch of the union of the sets.
+let union_sketch = left_sketch | right_sketch;
+let union: HashSet<u64> = left.union(&right).copied().collect();
+assert_eq!(union_sketch, union.iter().collect());
+```
+
+The word type (`u8`, `u16`, `u32`, `u64`, `usize`) and the number of permutations are compile-time parameters that trade memory for accuracy.
+
 ## Reason for this implementation
 I wanted to benchmark how well does MinHash estimates the Jaccard similarity between two sets and how well does it compare with other methods such as [HyperLogLog](https://github.com/LucaCappelletti94/hyperloglog-rs). The implementations I have found used more memory than it was necessary by the data structure, and I wanted to compare the performance of MinHash with other methods using the same amount of memory. Additionally, often the methods were not optimized in any way shape or form, and I wanted to compare as fairly as possible MinHash with my rather well optimized implementation of HyperLogLog. I have benchmarked MinHash on many different universe sizes, [you can find the full benchmark report here](https://github.com/LucaCappelletti94/minhash-rs/blob/main/BENCHMARKS.md).
 

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -2,7 +2,6 @@
 
 use core::hash::{Hash, Hasher};
 use core::sync::atomic::Ordering;
-use core::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize};
 
 use fnv::FnvHasher;
 use siphasher::sip128::SipHasher13;
@@ -67,46 +66,6 @@ pub trait AtomicFetchMin {
     /// * `ordering` - The ordering to use.
     ///
     fn set_min(&self, value: Self::Word, ordering: Ordering);
-}
-
-impl AtomicFetchMin for AtomicU8 {
-    type Word = u8;
-
-    fn set_min(&self, value: Self::Word, ordering: Ordering) {
-        self.fetch_min(value, ordering);
-    }
-}
-
-impl AtomicFetchMin for AtomicU16 {
-    type Word = u16;
-
-    fn set_min(&self, value: Self::Word, ordering: Ordering) {
-        self.fetch_min(value, ordering);
-    }
-}
-
-impl AtomicFetchMin for AtomicU32 {
-    type Word = u32;
-
-    fn set_min(&self, value: Self::Word, ordering: Ordering) {
-        self.fetch_min(value, ordering);
-    }
-}
-
-impl AtomicFetchMin for AtomicU64 {
-    type Word = u64;
-
-    fn set_min(&self, value: Self::Word, ordering: Ordering) {
-        self.fetch_min(value, ordering);
-    }
-}
-
-impl AtomicFetchMin for AtomicUsize {
-    type Word = usize;
-
-    fn set_min(&self, value: Self::Word, ordering: Ordering) {
-        self.fetch_min(value, ordering);
-    }
 }
 
 /// Generates the per-permutation hash streams a MinHash uses for a value.
@@ -255,30 +214,47 @@ pub trait AsAtomic {
     fn as_atomic(&mut self) -> &[Self::AtomicWord];
 }
 
-macro_rules! impl_as_atomic {
-    ($word:ty, $atomic:ty) => {
-        impl<const PERMUTATIONS: usize> AsAtomic for MinHash<$word, PERMUTATIONS> {
-            type AtomicWord = $atomic;
+// Emit the atomic implementations for one word width, gated on the target
+// actually having an atomic of that width. Targets without (for example) 64-bit
+// atomics simply do not get the `u64` atomic API, while the rest of the crate
+// (and narrower atomics) keeps working. The atomic type is referenced through
+// its full path so the gated-out widths are never even named.
+macro_rules! atomic_impls {
+    ($word:ty, $atomic:ident, $has:literal) => {
+        #[cfg(target_has_atomic = $has)]
+        impl AtomicFetchMin for core::sync::atomic::$atomic {
+            type Word = $word;
 
-            fn as_atomic(&mut self) -> &[$atomic] {
+            fn set_min(&self, value: Self::Word, ordering: Ordering) {
+                self.fetch_min(value, ordering);
+            }
+        }
+
+        #[cfg(target_has_atomic = $has)]
+        impl<const PERMUTATIONS: usize> AsAtomic for MinHash<$word, PERMUTATIONS> {
+            type AtomicWord = core::sync::atomic::$atomic;
+
+            fn as_atomic(&mut self) -> &[core::sync::atomic::$atomic] {
                 let words: &mut [$word] = self.as_mut();
-                // SAFETY: `$atomic` has the same size and alignment as `$word`,
+                // SAFETY: the atomic has the same size and alignment as `$word`,
                 // so the slice layout (data pointer and length) is identical.
                 // The atomic view is derived from a unique `&mut` borrow, so it
                 // carries read-write provenance, and that exclusive borrow is
                 // held for the lifetime of the returned slice, ruling out
                 // concurrent non-atomic access to the same memory.
-                unsafe { core::mem::transmute::<&mut [$word], &[$atomic]>(words) }
+                unsafe {
+                    core::mem::transmute::<&mut [$word], &[core::sync::atomic::$atomic]>(words)
+                }
             }
         }
     };
 }
 
-impl_as_atomic!(u8, AtomicU8);
-impl_as_atomic!(u16, AtomicU16);
-impl_as_atomic!(u32, AtomicU32);
-impl_as_atomic!(u64, AtomicU64);
-impl_as_atomic!(usize, AtomicUsize);
+atomic_impls!(u8, AtomicU8, "8");
+atomic_impls!(u16, AtomicU16, "16");
+atomic_impls!(u32, AtomicU32, "32");
+atomic_impls!(u64, AtomicU64, "64");
+atomic_impls!(usize, AtomicUsize, "ptr");
 
 /// Concurrent insertion into a slice of atomic MinHash words.
 ///


### PR DESCRIPTION
Rounds out the crate for publishing with four additions.

It declares a minimum supported Rust version of 1.75, which is the floor the code actually needs (the IterHashes trait returns impl Trait from trait methods, stabilized in 1.75). A new CI job builds on 1.75.0 to keep the MSRV honest.

It adds a CHANGELOG documenting the 0.2 to 0.3 breaking changes and fixes, and a runnable usage example in the README. Since the README is included as the crate-level documentation, that example runs as a doctest.

It gates the atomic implementations on target_has_atomic, so the crate compiles on no_std targets that lack the relevant atomics (the core sketch still works, only the atomic insert API for an unavailable width is dropped). A second no-std CI build, against thumbv6m-none-eabi which has no atomic CAS, guards this. Host tests, doctests, clippy, fmt, Miri, the bare-metal build with atomics, and the MSRV build all pass.
