### PR TITLE
Add cargo-audit to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,23 @@ jobs:
         # I/O) that is unsuitable for the Miri interpreter.
         run: cargo miri test --lib --test test_atomic --test test_atomic_variants
 
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+      - name: Audit dependencies for known vulnerabilities
+        # Checks the dependency tree against the RustSec advisory database.
+        # --deny warnings also fails on unmaintained crates and yanked versions,
+        # not just on outright vulnerabilities.
+        run: cargo audit --deny warnings
+
   coverage:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ serde-big-array = "0.5"
 serde_json = "1.0"
 rayon = "1.5"
 hyperloglog-rs = "0.1"
-indicatif = { version = "0.15", features = ["rayon"] }
+indicatif = { version = "0.18", features = ["rayon"] }
 
 # Optimize tests so the data-structure heavy tests run quickly, while keeping
 # overflow checks and debug assertions on to catch bugs.


### PR DESCRIPTION
This adds a cargo-audit job to the Rust workflow so CI checks the dependency tree against the RustSec advisory database on every push and pull request. The job installs cargo-audit via taiki-e/install-action on the stable toolchain and runs cargo audit --deny warnings, which fails not only on outright vulnerabilities but also on unmaintained crates and yanked versions.

Enabling the gate surfaced RUSTSEC-2025-0119: the unmaintained number_prefix crate was being pulled in transitively through indicatif 0.15. This bumps the indicatif dev-dependency to 0.18, which dropped number_prefix entirely, so the audit now passes clean. indicatif is dev-only and the test_jaccard integration test still compiles against the new version, and since the MSRV build job only runs cargo build (which does not compile dev-dependencies) the MSRV is unaffected.